### PR TITLE
Fix Slot 2 (mmc2) initialization timeout on Miyoo Flip

### DIFF
--- a/package/kernels/kernel-gammaos/0002-mmc-dw_mmc-fix-slot-2-detection-for-Miyoo-Flip.patch
+++ b/package/kernels/kernel-gammaos/0002-mmc-dw_mmc-fix-slot-2-detection-for-Miyoo-Flip.patch
@@ -1,0 +1,42 @@
+diff --git a/drivers/mmc/host/dw_mmc.c b/drivers/mmc/host/dw_mmc.c
+index aaaaaaa..bbbbbbb 100644
+--- a/drivers/mmc/host/dw_mmc.c
++++ b/drivers/mmc/host/dw_mmc.c
+@@ -2960,6 +2960,8 @@ static int dw_mci_init_slot(struct dw_mci *host)
+ 	struct mmc_host *mmc;
+ 	struct dw_mci_slot *slot;
+ 	int ret;
++	struct resource *res;
++	unsigned long base_addr = 0;
+ 
+ 	mmc = mmc_alloc_host(sizeof(struct dw_mci_slot), host->dev);
+ 	if (!mmc)
+@@ -3003,6 +3005,27 @@ static int dw_mci_init_slot(struct dw_mci *host)
+ 
+ 	dw_mci_get_cd(mmc);
+ 
++	/* [Miyoo Flip Patch] Fix for Slot 2 (fe2c0000) stability */
++	res = platform_get_resource(to_platform_device(host->dev), IORESOURCE_MEM, 0);
++	if (res)
++		base_addr = res->start;
++
++	if (base_addr == 0xfe2c0000) {
++		dev_info(host->dev, "Miyoo Flip: Slot 2 detected. Applying stabilization fix (Delay+HS)...\n");
++
++		/* 1. Force 500ms delay for power stabilization */
++		mdelay(500);
++
++		/* 2. Limit capabilities to High-Speed (50MHz, 3.3V) only */
++		/* Matches Stock OS behavior to prevent UHS negotiation failures */
++		mmc->caps &= ~(MMC_CAP_UHS_SDR12 | MMC_CAP_UHS_SDR25 |
++			       MMC_CAP_UHS_SDR50 | MMC_CAP_UHS_SDR104 |
++			       MMC_CAP_UHS_DDR50);
++		mmc->caps &= ~MMC_CAP_1_8V_DDR;
++		if (mmc->f_max > 50000000)
++			mmc->f_max = 50000000;
++	}
++
+ 	ret = mmc_add_host(mmc);
+ 	if (ret)
+ 		goto err_host_allocated;
+


### PR DESCRIPTION
**Summary**
This PR fixes an issue where high-performance SD cards (e.g., SanDisk 1TB Extreme) fail to initialize in Slot 2 (`mmc2` / `0xfe2c0000`) on the Miyoo Flip.

**The Issue**
Users utilizing high-capacity/high-speed cards in the second slot experience recurring `Timeout sending command` errors during boot or hot-plug. The kernel attempts to negotiate UHS modes or fails to stabilize voltage in time, leading to the slot being disabled.

**The Fix**
Applied a kernel patch to `drivers/mmc/host/dw_mmc.c` that targets the Miyoo Flip's Slot 2 base address (`0xfe2c0000`). The patch does the following:
1.  **Adds a 500ms delay** before host registration to ensure power stabilization.
2.  **Forces High-Speed mode (50MHz, 3.3V)** by disabling UHS capabilities (SDR12/25/50/104) and 1.8V signaling.
    * *Note: This mirrors the behavior of the Official Miyoo Stock Firmware, which also runs Slot 2 at 50MHz for stability.*
```
/* Stock log */
[   73.958658] mmc_host mmc1: Bus speed (slot 0) = 50000000Hz (slot req 50000000Hz, actual 50000000HZ div = 0)
[   73.958701] mmc1: new ultra high speed SDR25 SDXC card at address aaaa
[   73.962085] mmcblk1: mmc1:aaaa SN01T 954 GiB 
[   73.973877]  mmcblk1: p1 p2 p3 p4
[   74.602811] EXT4-fs (mmcblk1p4): recovery complete
[   74.602836] EXT4-fs (mmcblk1p4): mounted filesystem with ordered data mode. Opts: (null)
[   75.485894] RTW: Turbo EDCA =0xa42b
[   76.649635] vccio_sd: Restricting voltage, 3300000-1950000uV
[   76.649656] vccio_sd: Restricting voltage, 3000000-1950000uV
[   76.649682] vccio_sd: Restricting voltage, 3300000-1950000uV
[   76.649686] vccio_sd: Restricting voltage, 2700000-1950000uV
[   76.924698] mmc_host mmc2: Bus speed (slot 0) = 50000000Hz (slot req 50000000Hz, actual 50000000HZ div = 0)
[   76.924850] mmc2: new high speed SDXC card at address aaaa
[   76.928259] mmcblk2: mmc2:aaaa SN01T 954 GiB 
[   76.946423]  mmcblk2: p1
```

**Verification**
Tested on KNULLI (Miyoo Flip).
* **Before:** `mmc2: Timeout sending command` followed by `vccio_sd: Restricting voltage` loop and failure.
* **After:** Card is correctly detected as `mmcblk2` running at 50MHz immediately after boot.