### PR TITLE
Fix bluetooth audio race condition on resume

### DIFF
--- a/board/fsoverlay/usr/bin/knulli-bluetooth-agent
+++ b/board/fsoverlay/usr/bin/knulli-bluetooth-agent
@@ -406,8 +406,16 @@ def refresh_audio_on_connect(properties):
   for i in range(100):
     sinks = subprocess.check_output(["pactl", "list", "short", "sinks"], encoding='utf-8')
     if "bluez_" in sinks:
-      current_output = subprocess.check_output(["knulli-audio", "get"], encoding='utf-8').strip()
-      subprocess.run(["knulli-audio", "set", current_output])
+      sink_name = ""
+      for line in sinks.splitlines():
+        if "bluez_" in line:
+          sink_name = line.split()[1]
+          break
+
+      time.sleep(0.5)
+      subprocess.run(["knulli-audio", "set", sink_name])
+      subprocess.run(["pactl", "set-sink-mute", sink_name, "0"])
+
       logging.info("Bluetooth audio sink detected: proceeding with audio refresh.")
       return
     time.sleep(0.1)


### PR DESCRIPTION
### Summary
This PR resolves an issue where Bluetooth audio fails to resume output correctly after waking the Miyoo Flip from sleep mode.

### The Issue
When waking the device from deep sleep, the Bluetooth controller and audio hardware undergo a reset cycle. The previous logic triggered `knulli-audio set auto` immediately upon reconnection.

The `auto` logic within the `knulli-audio` script executes hardware mixer commands (`amixer`) which often conflict with the audio hardware (ALSA/PipeWire) while it is still initializing. This **race condition** caused PipeWire to lose the sink connection or crash (resulting in `auto_null`), leaving the device silent or incorrectly reverting to the internal speaker.

### The Fix
Updated the `knulli-bluetooth-agent` script to optimize the reconnection logic and bypass hardware conflicts:

1. **Direct Sink Targeting:** The agent now detects the specific Bluetooth `sink_name` via `pactl` and passes it directly to `knulli-audio set`.
   * *Why:* Passing a specific sink name allows the script to bypass the heavy hardware initialization checks and `amixer` calls inherent to the `auto` mode, preventing the race condition.

2. **Explicit Wake-up:** Added an explicit `pactl set-sink-mute ... 0` command immediately after switching.
   * *Why:* Ensures the audio sink is unmuted and active immediately after the handover.

### Verification
**1. Miyoo Flip (Device with issue):**
Tested on KNULLI with Bluetooth headphones.
* **Before:** Audio output remained on the internal speaker, became silent, or the audio system crashed (`auto_null`) upon waking from sleep.
* **After:** Audio automatically and reliably switches back to the Bluetooth headset upon reconnection after sleep.

**2. RG35XXSP (Regression Test):**
* Confirmed that the updated logic works correctly on devices that were already functioning properly, ensuring no regressions.