### PR TITLE
Add reconnect settings for Bluetooth configuration

### DIFF
--- a/board/fsoverlay/etc/bluetooth/main.conf
+++ b/board/fsoverlay/etc/bluetooth/main.conf
@@ -6,6 +6,8 @@ FastConnectable = true
 
 [Policy]
 AutoEnable=true
+ReconnectAttempts=20
+ReconnectIntervals=3
 
 # LE section for Xbox X|S controllers
 # try uncommenting the below options


### PR DESCRIPTION
Configured Bluetooth reconnection policy (20 attempts, 3s interval) to improve auto-connect reliability.