### PR TITLE
Fixed some issues with standalone ScummVM

### DIFF
--- a/package/emulationstation/knulli-es-system/es_features.yml
+++ b/package/emulationstation/knulli-es-system/es_features.yml
@@ -9623,10 +9623,10 @@ scummvm:
           prompt: STRETCH MODE
           description: Stretches the output to fill the display area.
           choices:
-              "Center (Default)":     "centre"
+              "Fit resolution scale (Default)": "fit"
+              "Center":     "centre"
               "Pixel Perfect":        "pixel-perfect"
               "Even Pixels":          "even-pixels"
-              "Fit resolution scale": "fit"
               "Stretch to screen":    "stretch"
               "Fit 4:3 Aspect Ratio": "fit_force_aspect"
       scumm_renderer:

--- a/package/system/knulli-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/system/knulli-configgen/configgen/configgen/emulatorlauncher.py
@@ -254,7 +254,7 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
     return exitCode
 
 def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution: Resolution, bordersSize: str | None, bordersRatio: str | None):
-    if generator.supportsInternalBezels():
+    if generator.supportsInternalBezels() or not generator.supportsExternalBezels():
         eslog.debug(f"skipping bezels for emulator {system.config['emulator']}")
         return None
     # no good reason for a bezel
@@ -309,6 +309,10 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
     screen_ratio = gameResolution["width"] / gameResolution["height"]
     bezel_ratio  = bezel_width / bezel_height
 
+    if (bezel_width == gameResolution["width"] and bezel_height == gameResolution["height"]):
+        eslog.debug("game resolution equals bezel size - no bezel applied")
+        return None
+
     # the screen and bezel ratio must be approximatly the same
     if bordersSize is None:
         if abs(screen_ratio - bezel_ratio) > max_ratio_delta:
@@ -330,6 +334,7 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
 
     ## the bezel left and right cover must be maximum
     ingame_ratio = generator.getInGameRatio(system.config, gameResolution, rom)
+    eslog.debug(f"ingame ratio: {ingame_ratio}")
     img_height = bezel_height
     img_width  = img_height * ingame_ratio
 

--- a/package/system/knulli-configgen/configgen/configgen/generators/Generator.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/Generator.py
@@ -39,6 +39,10 @@ class Generator(metaclass=ABCMeta):
     def supportsInternalBezels(self) -> bool:
         return False
 
+    # Most emulators support external bezels, however, ScummVM does not
+    def supportsExternalBezels(self) -> bool:
+        return True
+
     # mangohud must be called by the generator itself (wine based emulator for example)
     def hasInternalMangoHUDCall(self) -> bool:
         return False

--- a/package/system/knulli-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -7,6 +7,7 @@ from ... import Command
 from ...batoceraPaths import BIOS, CACHE, CONFIGS, SAVES, SCREENSHOTS, ensure_parents_and_open, mkdir_if_not_exists
 from ...controller import generate_sdl_game_controller_config
 from ...utils.configparser import CaseSensitiveConfigParser
+from ...utils.videoMode import getCurrentResolution
 from ..Generator import Generator
 
 if TYPE_CHECKING:
@@ -27,8 +28,11 @@ class ScummVMGenerator(Generator):
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
         rom_path = Path(rom)
 
-        # crete /userdata/bios/scummvm/extra folder if it doesn't exist
+        # create /userdata/bios/scummvm/extra folder if it doesn't exist
         mkdir_if_not_exists(scummExtra)
+
+        # create /userdata/screenshots folder if it doesn't exist
+        mkdir_if_not_exists(SCREENSHOTS)
 
         # create / modify scummvm config file as needed
         scummConfig = CaseSensitiveConfigParser()
@@ -83,7 +87,7 @@ class ScummVMGenerator(Generator):
         if system.isOptSet("scumm_scale"):
             commandArray.append(f"--scale-factor={system.config['scumm_scale']}")
         else:
-            commandArray.append("--scale-factor=3")
+            commandArray.append("--scale-factor=1")
 
         # sclaer mode
         if system.isOptSet("scumm_scaler_mode"):
@@ -95,7 +99,7 @@ class ScummVMGenerator(Generator):
         if system.isOptSet("scumm_stretch"):
             commandArray.append(f"--stretch-mode={system.config['scumm_stretch']}")
         else:
-            commandArray.append("--stretch-mode=center")
+            commandArray.append("--stretch-mode=fit")
 
         # renderer
         if system.isOptSet("scumm_renderer"):
@@ -129,6 +133,12 @@ class ScummVMGenerator(Generator):
         )
 
     def getInGameRatio(self, config, gameResolution, rom):
-        if ("scumm_stretch" in config and config["scumm_stretch"] == "fit_force_aspect") or ("scumm_stretch" in config and config["scumm_stretch"] == "pixel-perfect"):
-            return 4/3
-        return 16/9
+        if ("scumm_stretch" in config and config["scumm_stretch"] == "stretch"):
+            resolutionObj = getCurrentResolution()
+            aspectRatio = resolutionObj["width"] / resolutionObj["height"]
+            return aspectRatio
+        # Not sure if this is entirely correct, but ScummVM games are mostly 4:3 unless they have been stretched
+        return 4/3
+    
+    def supportsExternalBezels(self) -> bool:
+        return False


### PR DESCRIPTION
Fixes a couple of issues with standalone ScummVM:

* ScummVM refuses to load if `/userdata/screenshots` doesn't exist; I hard-coded it to make the directory if it doesn't exist, yet, during configgen
* ln latest alphas, standalone ScummVM **does not show any visuals** when **bezel decorations are enabled** - I therefore introduced a possible solution for **us** to disable bezels on a per-emulator basis in configgen rather than for the entire system/device via configuration