### PR TITLE
Allow dumping SRM to file while in-game

### DIFF
--- a/package/emulationstation/knulli-es-system/es_features.yml
+++ b/package/emulationstation/knulli-es-system/es_features.yml
@@ -75,7 +75,7 @@ shared:
       choices:
         "On":  1
         "Off": 0
-    autosave_interval:
+    srm_update_interval:
       prompt: SRM FILE UPDATE INTERVAL (MINUTES)
       description: For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes.
       choices:
@@ -563,7 +563,7 @@ global:
   shared: [powermode, batterymode, tdp, videomode, ratio, shaderset, smooth, integerscale, integeroverscale, integerscaleaxis, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, toggle_fast_forward, runahead, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, hotkey_up, hotkey_down, hotkey_left, hotkey_right, hotkey_y, hotkey_x, hotkey_b, hotkey_a, hotkey_l1, hotkey_r1, hotkey_l2, hotkey_r2]
 
 libretro:
-  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, integeroverscale, integerscaleaxis, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, autosave_interval, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, hotkey_up, hotkey_down, hotkey_left, hotkey_right, hotkey_y, hotkey_x, hotkey_b, hotkey_a, hotkey_l1, hotkey_r1, hotkey_l2, hotkey_r2]
+  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, integeroverscale, integerscaleaxis, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, srm_update_interval, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, hotkey_up, hotkey_down, hotkey_left, hotkey_right, hotkey_y, hotkey_x, hotkey_b, hotkey_a, hotkey_l1, hotkey_r1, hotkey_l2, hotkey_r2]
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, bcm2711, bcm2712, a3gen2]

--- a/package/emulationstation/knulli-es-system/es_features.yml
+++ b/package/emulationstation/knulli-es-system/es_features.yml
@@ -79,7 +79,7 @@ shared:
       prompt: SRM FILE UPDATE INTERVAL (MINUTES)
       description: For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes.
       choices:
-        "ONLY ON GAME EXIT (DEFAULT)":  ""
+        "ONLY ON GAME EXIT (DEFAULT)":  "0"
         "1": "1"
         "5": "5"
         "10": "10"

--- a/package/emulationstation/knulli-es-system/es_features.yml
+++ b/package/emulationstation/knulli-es-system/es_features.yml
@@ -75,18 +75,10 @@ shared:
       choices:
         "On":  1
         "Off": 0
-    srm_update_interval:
-      prompt: SRM FILE UPDATE INTERVAL
-      description: For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X seconds/minutes.
-      choices:
-        "5 Sec.": "5"
-        "10 Sec.": "10"
-        "15 Sec.": "15"
-        "30 Sec.": "30"
-        "1 Min.": "60"
-        "5 Min.": "300"
-        "10 Min.": "600"
-        "ONLY ON GAME EXIT":  "0"
+    srm_dump_ingame:
+      prompt: WRITE IN-GAME SAVES TO DISK WHILE IN GAME
+      description: For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated either within 10 seconds after saved or only on game exit.
+      preset: switchauto
     shaderset:
       prompt: SHADER SET
       submenu: GAME RENDERING & SHADERS

--- a/package/emulationstation/knulli-es-system/es_features.yml
+++ b/package/emulationstation/knulli-es-system/es_features.yml
@@ -76,16 +76,17 @@ shared:
         "On":  1
         "Off": 0
     srm_update_interval:
-      prompt: SRM FILE UPDATE INTERVAL (MINUTES)
-      description: For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes.
+      prompt: SRM FILE UPDATE INTERVAL
+      description: For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X seconds/minutes.
       choices:
-        "ONLY ON GAME EXIT (DEFAULT)":  "0"
-        "1": "1"
-        "5": "5"
-        "10": "10"
-        "15": "15"
-        "30": "30"
-        "60": "60"
+        "5 Sec.": "5"
+        "10 Sec.": "10"
+        "15 Sec.": "15"
+        "30 Sec.": "30"
+        "1 Min.": "60"
+        "5 Min.": "300"
+        "10 Min.": "600"
+        "ONLY ON GAME EXIT":  "0"
     shaderset:
       prompt: SHADER SET
       submenu: GAME RENDERING & SHADERS

--- a/package/emulationstation/knulli-es-system/es_features.yml
+++ b/package/emulationstation/knulli-es-system/es_features.yml
@@ -75,6 +75,17 @@ shared:
       choices:
         "On":  1
         "Off": 0
+    autosave_interval:
+      prompt: SRM FILE UPDATE INTERVAL (MINUTES)
+      description: For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes.
+      choices:
+        "ONLY ON GAME EXIT (DEFAULT)":  ""
+        "1": "1"
+        "5": "5"
+        "10": "10"
+        "15": "15"
+        "30": "30"
+        "60": "60"
     shaderset:
       prompt: SHADER SET
       submenu: GAME RENDERING & SHADERS
@@ -552,7 +563,7 @@ global:
   shared: [powermode, batterymode, tdp, videomode, ratio, shaderset, smooth, integerscale, integeroverscale, integerscaleaxis, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, toggle_fast_forward, runahead, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, hotkey_up, hotkey_down, hotkey_left, hotkey_right, hotkey_y, hotkey_x, hotkey_b, hotkey_a, hotkey_l1, hotkey_r1, hotkey_l2, hotkey_r2]
 
 libretro:
-  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, integeroverscale, integerscaleaxis, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, hotkey_up, hotkey_down, hotkey_left, hotkey_right, hotkey_y, hotkey_x, hotkey_b, hotkey_a, hotkey_l1, hotkey_r1, hotkey_l2, hotkey_r2]
+  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, integeroverscale, integerscaleaxis, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, autosave_interval, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, hotkey_up, hotkey_down, hotkey_left, hotkey_right, hotkey_y, hotkey_x, hotkey_b, hotkey_a, hotkey_l1, hotkey_r1, hotkey_l2, hotkey_r2]
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, bcm2711, bcm2712, a3gen2]

--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -819,6 +819,12 @@ def createLibretroConfig(generator: Generator, system: Emulator, controllers: Co
         retroarchConfig['savestate_auto_save'] = 'false'
         retroarchConfig['savestate_auto_load'] = 'false'
 
+    # SRM update interval option
+    if system.isOptSet('autosave_interval') and system.getOptString('autosave_interval') != "":
+        srmFileUpdateIntervalMinutes = int(system.config['autosave_interval'])
+        srmFileUpdateIntervalSeconds = srmFileUpdateIntervalMinutes * 60
+        retroarchConfig['autosave_interval'] = str(srmFileUpdateIntervalSeconds)
+
     if system.isOptSet('incrementalsavestates') and not system.getOptBoolean('incrementalsavestates'):
         retroarchConfig['savestate_auto_index'] = 'false'
         retroarchConfig['savestate_max_keep'] = '50'

--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -820,10 +820,10 @@ def createLibretroConfig(generator: Generator, system: Emulator, controllers: Co
         retroarchConfig['savestate_auto_load'] = 'false'
 
     # SRM update interval option
-    if system.isOptSet('srm_update_interval') and system.getOptString('srm_update_interval') != "":
-        retroarchConfig['autosave_interval'] = str(int(system.config['srm_update_interval']))
+    if system.isOptSet('srm_dump_ingame') and system.getOptBoolean('srm_dump_ingame') == True:
+        retroarchConfig['autosave_interval'] = '10' # default RA autosave interval of 10 seconds
     else:
-        retroarchConfig['autosave_interval'] = '60'  # 1 minute by defeault
+        retroarchConfig['autosave_interval'] = '0'  # disable autosave interval
 
     if system.isOptSet('incrementalsavestates') and not system.getOptBoolean('incrementalsavestates'):
         retroarchConfig['savestate_auto_index'] = 'false'

--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -820,10 +820,12 @@ def createLibretroConfig(generator: Generator, system: Emulator, controllers: Co
         retroarchConfig['savestate_auto_load'] = 'false'
 
     # SRM update interval option
-    if system.isOptSet('autosave_interval') and system.getOptString('autosave_interval') != "":
-        srmFileUpdateIntervalMinutes = int(system.config['autosave_interval'])
+    if system.isOptSet('srm_update_interval') and system.getOptString('srm_update_interval') != "":
+        srmFileUpdateIntervalMinutes = int(system.config['srm_update_interval'])
         srmFileUpdateIntervalSeconds = srmFileUpdateIntervalMinutes * 60
         retroarchConfig['autosave_interval'] = str(srmFileUpdateIntervalSeconds)
+    else:
+        retroarchConfig['autosave_interval'] = '0'  # Disabled by default
 
     if system.isOptSet('incrementalsavestates') and not system.getOptBoolean('incrementalsavestates'):
         retroarchConfig['savestate_auto_index'] = 'false'

--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -821,11 +821,9 @@ def createLibretroConfig(generator: Generator, system: Emulator, controllers: Co
 
     # SRM update interval option
     if system.isOptSet('srm_update_interval') and system.getOptString('srm_update_interval') != "":
-        srmFileUpdateIntervalMinutes = int(system.config['srm_update_interval'])
-        srmFileUpdateIntervalSeconds = srmFileUpdateIntervalMinutes * 60
-        retroarchConfig['autosave_interval'] = str(srmFileUpdateIntervalSeconds)
+        retroarchConfig['autosave_interval'] = str(int(system.config['srm_update_interval']))
     else:
-        retroarchConfig['autosave_interval'] = '0'  # Disabled by default
+        retroarchConfig['autosave_interval'] = '60'  # 1 minute by defeault
 
     if system.isOptSet('incrementalsavestates') and not system.getOptBoolean('incrementalsavestates'):
         retroarchConfig['savestate_auto_index'] = 'false'


### PR DESCRIPTION
Ties in with this ES update: https://github.com/knulli-cfw/batocera-emulationstation/pull/95

Both are required to be merged for the feature to work.