### PR TITLE
Adding new service enable_ssh_server

### DIFF
--- a/board/fsoverlay/usr/share/knulli/services/enable_ssh_server
+++ b/board/fsoverlay/usr/share/knulli/services/enable_ssh_server
@@ -7,7 +7,6 @@ case "$1" in
                 knulli-settings-set system.ssh.enabled 1
                 ;;
         stop)
-                # code here is executed on-the-fly
                 echo -n "Disabling SSH Server"
                 knulli-settings-set system.ssh.enabled 0
                 ;;

--- a/board/fsoverlay/usr/share/knulli/services/enable_ssh_server
+++ b/board/fsoverlay/usr/share/knulli/services/enable_ssh_server
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# requires restart for changes to take effect
+case "$1" in
+        start)
+                echo -n "Enabling SSH Server"
+                knulli-settings-set system.ssh.enabled 1
+                ;;
+        stop)
+                # code here is executed on-the-fly
+                echo -n "Disabling SSH Server"
+                knulli-settings-set system.ssh.enabled 0
+                ;;
+        *)
+                # other conditions
+                echo "Usage: $0 {start|stop}"
+                ;;
+esac
+
+exit 0


### PR DESCRIPTION
It changes the HOME configuration to enable/disable dropbear auto-start.

It should save some cpu-cycles/memory for those that don't need this feature daily.