### PR TITLE
Fixed achievements events not firing

### DIFF
--- a/package/system/knulli-configgen/scripts/call_achievements_hooks.sh
+++ b/package/system/knulli-configgen/scripts/call_achievements_hooks.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-for D in /var/run/emulationstation/scripts/achievements /userdata/system/configs/emulationstation/scripts/achievements
+for D in /var/run/emulationstation/scripts/achievements /userdata/system/configs/emulationstation/scripts/achievements /usr/share/emulationstation/scripts/achievements
+
 do
     find -L "${D}" -type f | while read X
     do


### PR DESCRIPTION
The internal `/usr/share/emulationstation/scripts/achievements` folder was missing from the script, hence achievement events weren't fired there and the RGB achievement script wasn't executed.

In previous builds, we had this change stored in overlays, e.g. here: https://github.com/knulli-cfw/distribution/blob/knulli-main/board/batocera/allwinner/a133/fsoverlay/usr/share/batocera/configgen/call_achievements_hooks.sh