### PR TITLE
Quick Resume Mode

### DIFF
--- a/board/allwinner/h700/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
+++ b/board/allwinner/h700/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
@@ -9,8 +9,8 @@ KEY_VOLUMEDOWN+BTN_TL2 0     /usr/bin/volume-button-release
 KEY_POWER 1                  /usr/bin/power-button
 KEY_POWER 0                  /usr/bin/power-button-release
 KEY_POWER+BTN_TL2 1          /usr/bin/knulli-power-led cycle
-BTN_TL+BTN_TR 1             /usr/bin/dpad-toggle
-BTN_TL+BTN_TR 0             /usr/bin/dpad-toggle-release
+BTN_TL+BTN_TR 1              /usr/bin/dpad-toggle
+BTN_TL+BTN_TR 0              /usr/bin/dpad-toggle-release
 BTN_TL+BTN_TL2 1             /usr/bin/knulli-game-switcher
 KEY_INSERT 1                 /usr/bin/lid-control close
 KEY_DELETE 1                 /usr/bin/lid-control open

--- a/board/allwinner/h700/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
+++ b/board/allwinner/h700/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
@@ -9,7 +9,8 @@ KEY_VOLUMEDOWN+BTN_TL2 0     /usr/bin/volume-button-release
 KEY_POWER 1                  /usr/bin/power-button
 KEY_POWER 0                  /usr/bin/power-button-release
 KEY_POWER+BTN_TL2 1          /usr/bin/knulli-power-led cycle
-# BTN_TL+BTN_TL2 1             /usr/bin/dpad-toggle
+BTN_TL+BTN_TR 1             /usr/bin/dpad-toggle
+BTN_TL+BTN_TR 0             /usr/bin/dpad-toggle-release
 BTN_TL+BTN_TL2 1             /usr/bin/knulli-game-switcher
 KEY_INSERT 1                 /usr/bin/lid-control close
 KEY_DELETE 1                 /usr/bin/lid-control open

--- a/board/allwinner/h700/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
+++ b/board/allwinner/h700/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
@@ -9,7 +9,8 @@ KEY_VOLUMEDOWN+BTN_TL2 0     /usr/bin/volume-button-release
 KEY_POWER 1                  /usr/bin/power-button
 KEY_POWER 0                  /usr/bin/power-button-release
 KEY_POWER+BTN_TL2 1          /usr/bin/knulli-power-led cycle
-BTN_TL+BTN_TL2 1             /usr/bin/dpad-toggle
+# BTN_TL+BTN_TL2 1             /usr/bin/dpad-toggle
+BTN_TL+BTN_TL2 1             /usr/bin/knulli-game-switcher
 KEY_INSERT 1                 /usr/bin/lid-control close
 KEY_DELETE 1                 /usr/bin/lid-control open
 BTN_TR+BTN_TL2+ 1            /usr/bin/knulli-softreset

--- a/board/allwinner/h700/fsoverlay/usr/bin/dpad-toggle
+++ b/board/allwinner/h700/fsoverlay/usr/bin/dpad-toggle
@@ -5,8 +5,20 @@ if knulli-board-capability "analogstick"; then
     exit 1
 fi
 
+LOCK_FILE="/var/run/dpad-toggle-script.lock"
+
+exec 200>"${LOCK_FILE}"
+if ! flock -n 200; then
+    exit 0
+fi
+
+trap 'flock -u 200;' EXIT
+
+DPAD_BUTTON_STATE="/var/run/dpad-toggle.held"
+
+# Threshold for long press to toggle d-pad (in seconds)
+LONG_PRESS_THRESHOLD=2
 DPAD_STATE_FILE="/sys/class/power_supply/axp2202-battery/nds_pwrkey"
-STATE=$(cat "$DPAD_STATE_FILE")
 
 check_ingame() {
     HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1234/runningGame")
@@ -20,22 +32,40 @@ do_notification() {
     curl -s http://localhost:1234/notify -d "$NOTIFICATION" >/dev/null
 }
 
-if [ "${STATE}" -eq 0 ]; then
-    if ! check_ingame; then
-        do_notification "Virtual Joystick ON"
-    fi
+toggle_dpad() {
+    STATE=$(cat "$DPAD_STATE_FILE")
 
-    knulli-rumble 0.1
-    echo 2 > "$DPAD_STATE_FILE"
+    if [ "${STATE}" -eq 0 ]; then
+        if ! check_ingame; then
+            do_notification "Virtual Joystick ON"
+        fi
+
+        knulli-rumble 0.1
+        echo 2 > "$DPAD_STATE_FILE"
+    else
+        if ! check_ingame; then
+            do_notification "Virtual Joystick OFF"
+        fi
+
+        knulli-rumble 0.1
+        sleep 0.2
+        knulli-rumble 0.1
+        echo 0 > "$DPAD_STATE_FILE"
+    fi
+}
+
+# Set starting state
+: > "$DPAD_BUTTON_STATE"
+
+# Wait for deletion of state file
+if inotifywait -qq -t "$LONG_PRESS_THRESHOLD" -e delete_self "$DPAD_BUTTON_STATE"; then
+    # Buttons released within timeout (short press) - do nothing
+    :
 else
-    if ! check_ingame; then
-        do_notification "Virtual Joystick OFF"
+    # Toggle if timeout is reached (long press)
+    if [ -f "$DPAD_BUTTON_STATE" ]; then
+        toggle_dpad
     fi
-
-    knulli-rumble 0.1
-    sleep 0.2
-    knulli-rumble 0.1
-    echo 0 > "$DPAD_STATE_FILE"
 fi
 
 exit 0

--- a/board/allwinner/h700/fsoverlay/usr/bin/dpad-toggle-release
+++ b/board/allwinner/h700/fsoverlay/usr/bin/dpad-toggle-release
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DPAD_BUTTON_STATE="/var/run/dpad-toggle.held"
+
+rm -f "$DPAD_BUTTON_STATE"
+
+exit 0

--- a/board/fsoverlay/usr/bin/knulli-game-switcher
+++ b/board/fsoverlay/usr/bin/knulli-game-switcher
@@ -9,16 +9,13 @@ check_ingame() {
     return 1  # 201 when not in game
 }
 
-    touch "$GAMESWITCHER_FLAG" # So the system or any scripts can tell if the shutdown sequence has started
-
-    if check_ingame; then
-        curl http://127.0.0.1:1234/gameswitcher
-        knulli-es-swissknife --emukill >/dev/null 2>&1
-    else
-        curl http://127.0.0.1:1234/gameswitcher
-    fi
-
-    # If ES is paused things will stall during shutdown
-    # /etc/init.d/S31emulationstation resume
+if check_ingame; then
+    # In game - create flag for Quick Resume mode and kill emulator
+    touch "$GAMESWITCHER_FLAG"
+    knulli-es-swissknife --emukill >/dev/null 2>&1
+else
+    # Not in game - ES is running, call the HTTP endpoint directly
+    curl -s http://127.0.0.1:1234/gameswitcher >/dev/null
+fi
 
 exit 0

--- a/board/fsoverlay/usr/bin/knulli-game-switcher
+++ b/board/fsoverlay/usr/bin/knulli-game-switcher
@@ -10,7 +10,8 @@ check_ingame() {
 }
 
 if check_ingame; then
-    # In game - create flag for Quick Resume mode and kill emulator
+    # In game - set pending flag via HTTP, create flag for Quick Resume mode, and kill emulator
+    curl -s http://127.0.0.1:1234/gameswitcher >/dev/null
     touch "$GAMESWITCHER_FLAG"
     knulli-es-swissknife --emukill >/dev/null 2>&1
 else

--- a/board/fsoverlay/usr/bin/knulli-game-switcher
+++ b/board/fsoverlay/usr/bin/knulli-game-switcher
@@ -9,14 +9,13 @@ check_ingame() {
     return 1  # 201 when not in game
 }
 
+# Call the game-switcher endpoint to invoke the UI
+curl -s http://127.0.0.1:1234/gameswitcher > /dev/null
+
 if check_ingame; then
-    # In game - set pending flag via HTTP, create flag for Quick Resume mode, and kill emulator
-    curl -s http://127.0.0.1:1234/gameswitcher >/dev/null
+    # In game - Create flag for Quick Resume mode, and kill emulator
     touch "$GAMESWITCHER_FLAG"
     knulli-es-swissknife --emukill >/dev/null 2>&1
-else
-    # Not in game - ES is running, call the HTTP endpoint directly
-    curl -s http://127.0.0.1:1234/gameswitcher >/dev/null
 fi
 
 exit 0

--- a/board/fsoverlay/usr/bin/knulli-game-switcher
+++ b/board/fsoverlay/usr/bin/knulli-game-switcher
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+GAMESWITCHER_FLAG="/var/run/gameswitcher.flag"
+
+check_ingame() {
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1234/runningGame")
+    test $? != 0                 && return 0
+    test "${HTTP_STATUS}" != 201 && return 0 # in game
+    return 1  # 201 when not in game
+}
+
+    touch "$GAMESWITCHER_FLAG" # So the system or any scripts can tell if the shutdown sequence has started
+
+    if check_ingame; then
+        curl http://127.0.0.1:1234/gameswitcher
+        knulli-es-swissknife --emukill >/dev/null 2>&1
+    else
+        curl http://127.0.0.1:1234/gameswitcher
+    fi
+
+    # If ES is paused things will stall during shutdown
+    # /etc/init.d/S31emulationstation resume
+
+exit 0


### PR DESCRIPTION
Inspired by the [Onion OS Game Switcher](https://onionui.github.io/docs/apps/game-switcher), I have built a version which replicates the functionality on Knulli.

### Changes
At a high level, these are the changes made in this repository:

#### All Chipsets
* Created the `knulli-game-switcher` script which gets called by the triggerhappy daemon when hotkeys are pressed

#### 700 Only
* Modified `multimedia_keys.conf` to assign game-switcher to 'function + select' and dpad-toggle to 'start + select (held down 2 secs)'.
* Modified `dpad-toggle` script to accommodate the 2 second hold and added `dpad_toggle_release` script.

#### Next Steps
Game switcher will still be accessible through the 'Quick Access' menu in the updated EmulationStation so folks can use it as I develop and test the hotkey scripting changes for each chipset.
