### PR TITLE
[H700] Fix screen rotation and enable independent HDMI/internal settings

### DIFF
--- a/board/allwinner/h700/fsoverlay/usr/bin/knulli-resolution
+++ b/board/allwinner/h700/fsoverlay/usr/bin/knulli-resolution
@@ -3,6 +3,7 @@
 DISPLAY="/sys/kernel/debug/dispdbg"
 HDMI_STATE="/sys/devices/platform/soc/6000000.hdmi/extcon/hdmi/state"
 read -r BOARD < "/boot/boot/knulli.board"
+LAST_STATE_FILE="/var/run/last_hdmi_state"
 
 f_usage() {
     echo "$0 listOutputs" >&2
@@ -29,6 +30,35 @@ set_fb() {
     fi
 
     fbset -g "$want_x" "$want_y" "$want_vx" "$want_vy" "$want_bpp"
+}
+
+# Sync the global display.rotate value with per-output keys.
+# When the output changes (HDMI plugged/unplugged), restore the rotation
+# previously saved for that output. When the output stays the same,
+# persist the current UI value to the active output key.
+sync_rotation_per_output() {
+    read -r STATE < "$HDMI_STATE"
+    [ -f "$LAST_STATE_FILE" ] && LAST_STATE=$(cat "$LAST_STATE_FILE") || LAST_STATE=""
+    CURRENT_ROT=$(knulli-settings-get display.rotate 2>/dev/null)
+    [ -z "$CURRENT_ROT" ] && CURRENT_ROT=0
+
+    if [ "$STATE" != "$LAST_STATE" ]; then
+        # Output changed — restore the rotation saved for this output
+        if [ "$STATE" = "HDMI=1" ]; then
+            SAVED=$(knulli-settings-get display.rotate.hdmi 2>/dev/null)
+        else
+            SAVED=$(knulli-settings-get display.rotate.internal 2>/dev/null)
+        fi
+        [ -n "$SAVED" ] && knulli-settings-set display.rotate "$SAVED"
+        echo "$STATE" > "$LAST_STATE_FILE"
+    else
+        # Same output — save current rotation to the active output key
+        if [ "$STATE" = "HDMI=1" ]; then
+            knulli-settings-set display.rotate.hdmi "$CURRENT_ROT"
+        else
+            knulli-settings-set display.rotate.internal "$CURRENT_ROT"
+        fi
+    fi
 }
 
 set_output() {
@@ -94,6 +124,7 @@ case "${ACTION}" in
     "listModes")
         ;;
     "setOutput")
+        sync_rotation_per_output
         read -r STATE < "$HDMI_STATE"
         if [ "$STATE" = "HDMI=1" ]; then
             set_output hdmi
@@ -103,12 +134,26 @@ case "${ACTION}" in
         ;;
     "currentResolution")
         if [ "$BOARD" = "rg28xx" ]; then
-            fbset | grep "geometry" | awk '{print $3"x"$2}'
+            RES=$(fbset | grep "geometry" | awk '{print $3"x"$2}')
         else
-            fbset | grep "geometry" | awk '{print $2"x"$3}'
+            RES=$(fbset | grep "geometry" | awk '{print $2"x"$3}')
+        fi
+        ROTATE=$(knulli-settings-get display.rotate 2>/dev/null)
+        if [ "$ROTATE" = "1" ] || [ "$ROTATE" = "3" ]; then
+            W=$(echo "$RES" | cut -dx -f1)
+            H=$(echo "$RES" | cut -dx -f2)
+            echo "${H}x${W}"
+        else
+            echo "$RES"
         fi
         ;;
     "currentOutput")
+        read -r STATE < "$HDMI_STATE"
+        if [ "$STATE" = "HDMI=1" ]; then
+            echo "hdmi"
+        else
+            echo "internal"
+        fi
         ;;
     "currentMode")
         ;;
@@ -117,6 +162,7 @@ case "${ACTION}" in
     "supportSystemReflection")
         ;;
     "supportSystemRotation")
+        exit 1
         ;;
     *)
         echo "error: invalid command ${ACTION}" >&2


### PR DESCRIPTION
## Summary

Enable independent display rotation for HDMI and internal outputs on Allwinner H700 devices (RG40XX-H, RG35XX-H/Plus, etc.), controllable directly from the EmulationStation System Settings menu without editing config files.

**Use case:** A user wants their HDMI output rotated 90° for a vertical arcade monitor, while keeping the internal screen at 0° (landscape).

## Problem

The EmulationStation UI only writes to the global `display.rotate` key in `knulli.conf`. However, the `emulationstation-standalone` launcher already supports per-output rotation keys (`display.rotate.hdmi`, `display.rotate.internal`) — it checks `display.rotate.{output}` first, then falls back to `display.rotate`.

The issue is that these per-output keys are never populated because:
1. The ES UI only writes `display.rotate` (global)
2. `currentOutput` was empty, so the launcher could never determine the active output

## Solution

Bridge the gap at the shell level with a `sync_rotation_per_output()` function that transparently manages per-output rotation values:

- **On output change** (HDMI plugged/unplugged): restores `display.rotate` from the saved value for the newly active output
- **On same output** (user changed rotation in UI): persists the current `display.rotate` value to the active output key (`display.rotate.hdmi` or `display.rotate.internal`)

This approach requires **zero changes to EmulationStation** — all logic is contained in the H700 `knulli-resolution` script.

## Changes (minimal, surgical edits)

| Change | Type | Original code modified? |
|--------|------|------------------------|
| `LAST_STATE_FILE` variable | 1 line added | No |
| `sync_rotation_per_output()` function | New block inserted | No (between existing functions) |
| `setOutput`: call sync function | 1 line added | No |
| `currentOutput`: return `hdmi` or `internal` | Fill empty case | No (was empty) |
| `supportSystemRotation`: return `exit 1` | 1 line in empty case | No (was empty) |
| `currentResolution`: swap WxH for portrait | Modified 2 lines | Yes — `fbset` output captured in variable |

**Only 2 original lines are modified.** Everything else is new code or fills previously empty case blocks.

## Configuration

Per-output rotation is managed automatically. Users simply change "SCREEN ROTATION" in ES System Settings as usual. The sync function handles the rest:

```
# These keys are managed automatically — users do NOT need to edit them
display.rotate=1            # Global (what ES UI reads/writes)
display.rotate.hdmi=1       # Saved HDMI rotation
display.rotate.internal=0   # Saved internal rotation
```

## Technical Details

- `supportSystemRotation` returns `exit 1` to force software rotation via `--screenrotate`. Hardware rotation on the H700 (via `fb0/rotate`) causes image artifacts on HDMI.
- `currentResolution` swaps width/height when rotation is 90° or 270° so ES themes render with correct aspect ratio in portrait mode.
- HDMI state tracking uses `/var/run/last_hdmi_state` (volatile, cleared on reboot).

## Testing

Tested on **RG40XX-H** running Knulli alpha `20260209`:
- ✅ HDMI output rotated 90° for vertical arcade setup
- ✅ Internal display unrotated when HDMI disconnected
- ✅ Rotation values persist independently per output
- ✅ HDMI hot-plug switching works correctly
- ✅ Rapid HDMI connect/disconnect does not cause hangs
- ✅ No regression on standard (non-rotated) usage
- ✅ Zero impact on devices without HDMI (sync is a no-op)