### PR TITLE
[H700] Fix reboot and poweroff from EmulationStation menu

### DIFF
--- a/board/allwinner/h700/fsoverlay/usr/bin/poweroff.sh
+++ b/board/allwinner/h700/fsoverlay/usr/bin/poweroff.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+knulli-shutdown -s

--- a/board/allwinner/h700/fsoverlay/usr/bin/reboot.sh
+++ b/board/allwinner/h700/fsoverlay/usr/bin/reboot.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+knulli-shutdown -r


### PR DESCRIPTION
## Summary
This PR fixes the issue where rebooting or powering off from the EmulationStation menu on Allwinner H700 devices (RG40XX, RG35XX) would result in the system getting stuck at the charging/splash screen instead of completing the reboot or shutting down cleanly.

## Problem
In the H700 architecture, EmulationStation is patched to call `reboot.sh` and `poweroff.sh` instead of the standard `shutdown` commands. However, these scripts were missing in the filesystem overlay for the H700 board. Without these scripts, the system fails to create the `/boot/restart.flag` file, which is necessary for the boot process (`rcS`) to skip the charging binary (`/usr/bin/charger`) during a reboot.

## Solution
Add `reboot.sh` and `poweroff.sh` to the H700 filesystem overlay. These scripts now correctly call `knulli-shutdown -r` and `knulli-shutdown -s`, ensuring that:
1. The `/boot/restart.flag` is created before rebooting.
2. The filesystem is synced.
3. The system reboots directly into the OS without requiring a manual power button press at the splash screen.

## Testing
Tested on **RG40XX-H** with Knulli alpha `20260209`.
- ✅ Reboot from ES menu now restarts completely into the game list.
- ✅ Shutdown from ES menu works as expected.