### PR TITLE
Adding color palette settings for the pcengine family

### DIFF
--- a/package/emulationstation/knulli-es-system/es_features.yml
+++ b/package/emulationstation/knulli-es-system/es_features.yml
@@ -4222,6 +4222,13 @@ libretro:
                 choices:
                     "Off":        disabled
                     "On":         enabled
+            sgx_palette:
+                prompt: COLOR PALETTE
+                group: ADVANCED OPTIONS
+                description: Color palette to apply.
+                choices:
+                    "RGB":          RGB
+                    "Composite":    Composite
     mednafen_wswan:
       features: [netplay, cheevos]
       shared: [rewind, autosave]
@@ -5082,6 +5089,13 @@ libretro:
                 choices:
                     "PCE Joypad": 1
                     "PCE Mouse":  2
+            pce_palette:
+                prompt: COLOR PALETTE
+                group: ADVANCED OPTIONS
+                description: Color palette to apply.
+                choices:
+                    "RGB":          RGB
+                    "Composite":    Composite
     pce_fast:
       features: [netplay, cheevos]
       shared: [rewind, autosave]
@@ -5097,6 +5111,13 @@ libretro:
                 choices:
                     "PCE Joypad": 1
                     "PCE Mouse":  2
+            pce_fast_palette:
+                prompt: COLOR PALETTE
+                group: ADVANCED OPTIONS
+                description: Color palette to apply.
+                choices:
+                    "RGB":          RGB
+                    "Composite":    Composite
     pcfx:
       features: [netplay, cheevos]
       shared: [rewind, autosave]

--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -952,7 +952,18 @@ def generateCoreSettings(coreSettings: UnixSettings, system: Emulator, rom: Path
             coreSettings.save('pce_nospritelimit', '"' + system.config['pce_nospritelimit'] + '"')
         else:
             coreSettings.save('pce_nospritelimit', '"enabled"')
-
+        # Set pce color palette
+        if system.config['core'] == 'pce':
+            if system.isOptSet('pce_palette'):
+                coreSettings.save('pce_palette', '"' + system.config['pce_palette'] + '"')
+            else:
+                coreSettings.save('pce_palette', '"Composite"')
+        else:
+            if system.isOptSet('pce_fast_palette'):
+                coreSettings.save('pce_fast_palette', '"' + system.config['pce_fast_palette'] + '"')
+            else:
+                coreSettings.save('pce_fast_palette', '"Composite"')
+                
     # Nec PC-8800
     if system.config['core'] == 'quasi88':
         # PC Model
@@ -1041,7 +1052,11 @@ def generateCoreSettings(coreSettings: UnixSettings, system: Emulator, rom: Path
             coreSettings.save('sgx_nospritelimit', '"' + system.config['sgx_nospritelimit'] + '"')
         else:
             coreSettings.save('sgx_nospritelimit', '"enabled"')
-
+        if system.isOptSet('sgx_palette'):
+            coreSettings.save('sgx_palette', '"' + system.config['sgx_palette'] + '"')
+        else:
+            coreSettings.save('sgx_palette', '"Composite"')
+            
     # Nec PC-FX
     if (system.config['core'] == 'pcfx'):
         # Remove 16-sprites-per-scanline hardware limit


### PR DESCRIPTION
Adding the ability to select RGB or Composite for the color palette applied by pce, pce_fast, and mednafen_supergrafx.