### PR TITLE
add RetroAchievements offline mode option

### DIFF
--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -912,7 +912,7 @@ def createLibretroConfig(generator: Generator, system: Emulator, controllers: Co
                 retroarchConfig['cheevos_richpresence_enable'] = 'true'
             else:
                 retroarchConfig['cheevos_richpresence_enable'] = 'false'
-            if not connected_to_internet():
+            if not connected_to_internet() and not (system.isOptSet('retroachievements.offline') and system.getOptBoolean('retroachievements.offline') == True):
                 retroarchConfig['cheevos_enable'] = 'false'
     else:
         retroarchConfig['cheevos_enable'] = 'false'

--- a/package/system/knulli-system/knulli.conf
+++ b/package/system/knulli-system/knulli.conf
@@ -295,6 +295,7 @@ updates.type=stable
 ## Set up your www.retroachievements.org username/password first
 ## Escape your special chars (# ; $) with a backslash. eg. $ becomes \$
 #global.retroachievements=0
+#global.retroachievements.offline=0
 #global.retroachievements.hardcore=0
 #global.retroachievements.leaderboards=0
 #global.retroachievements.verbose=0


### PR DESCRIPTION
## Summary
- add a new `global.retroachievements.offline` setting to `knulli.conf`
- keep `cheevos_enable` active in libretro config generation when that setting is enabled
- preserve the existing internet check behavior when offline mode is disabled

## Why
This allows KNULLI to keep RetroAchievements enabled for a local offline proxy setup without changing the default behavior for normal online-only RetroAchievements usage.

## Testing
- enabled `global.retroachievements.offline=1` in `/userdata/system/knulli.conf`
- verified that a cached game still launched with `cheevos_enable = true` while upstream RetroAchievements was unreachable
- verified that offline achievements were shown and submitted through RAOfflineProxy