### PR TITLE
fix(ti99): correct TI-99/4A config (speechsyn topology, Game Focus, on-board controls)

### DIFF
--- a/board/fsoverlay/usr/share/evmapy/ti99.keys
+++ b/board/fsoverlay/usr/share/evmapy/ti99.keys
@@ -1,0 +1,17 @@
+{
+    "actions_player1": [
+        { "trigger": "up",       "type": "key", "target": [ "KEY_UP" ],    "description": "Joystick Up" },
+        { "trigger": "down",     "type": "key", "target": [ "KEY_DOWN" ],  "description": "Joystick Down" },
+        { "trigger": "left",     "type": "key", "target": [ "KEY_LEFT" ],  "description": "Joystick Left" },
+        { "trigger": "right",    "type": "key", "target": [ "KEY_RIGHT" ], "description": "Joystick Right" },
+        { "trigger": "a",        "type": "key", "target": [ "KEY_LEFTCTRL" ], "description": "Fire" },
+        { "trigger": "b",        "type": "key", "target": [ "KEY_LEFTCTRL" ], "description": "Fire" },
+        { "trigger": "pageup",   "type": "key", "target": [ "KEY_1" ], "description": "TI 1" },
+        { "trigger": "pagedown", "type": "key", "target": [ "KEY_2" ], "description": "TI 2 (start cartridge)" },
+        { "trigger": "l2",       "type": "key", "target": [ "KEY_3" ], "description": "TI 3" },
+        { "trigger": "r2",       "type": "key", "target": [ "KEY_4" ], "description": "TI 4" },
+        { "trigger": "x",        "type": "key", "target": [ "KEY_5" ], "description": "TI 5" },
+        { "trigger": "select",   "type": "key", "target": [ "KEY_0" ], "description": "TI 0" },
+        { "trigger": ["hotkey","start"], "type": "key", "target": [ "KEY_ESC" ], "description": "Exit Emulator" }
+    ]
+}

--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -253,6 +253,7 @@ def createLibretroConfig(generator: Generator, system: Emulator, controllers: Co
     retroarchConfig['input_joypad_driver'] = 'udev'
     retroarchConfig['input_driver'] = 'udev'                    # driver for mouse/keyboard. udev required for guns.
     retroarchConfig['input_max_users'] = "16"                   # Allow up to 16 players
+    retroarchConfig['input_auto_game_focus'] = '2'              # Auto-enable Game Focus for keyboard cores (e.g. ti99/MAME computers) so keyboard/evmapy input reaches the core
 
     retroarchConfig['input_libretro_device_p1'] = '1'           # Default devices choices
     retroarchConfig['input_libretro_device_p2'] = '1'

--- a/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -135,11 +135,23 @@ def generateMAMEConfigs(playersControllers: ControllerMapping, system: Emulator,
             # TI-99 32k RAM expansion & speech modules
             # Don't enable 32k by default
             if system.name == "ti99":
-                commandLine += [ "-ioport", "peb" ]
-                if system.isOptSet("ti99_32kram") and system.getOptBoolean("ti99_32kram"):
-                    commandLine += ["-ioport:peb:slot2", "32kmem"]
-                if not system.isOptSet("ti99_speech") or (system.isOptSet("ti99_speech") and system.getOptBoolean("ti99_speech")):
-                    commandLine += ["-ioport:peb:slot3", "speech"]
+                # The speech synthesizer attaches to the console I/O port
+                # ("-ioport speechsyn"); the Peripheral Expansion Box chains into
+                # the synth's "extport" pass-through (real-hardware topology). PEB
+                # cards such as the 32K RAM expansion live in the PEB slots.
+                # The previous layout ("-ioport peb -ioport:peb:slot3 speech") used
+                # a non-existent slot option ('speech' is not a PEB card; the synth
+                # is 'speechsyn' on the console ioport), so lr-mame failed to load
+                # the machine (and older builds segfaulted on the bad argument).
+                ti99_speech = not system.isOptSet("ti99_speech") or system.getOptBoolean("ti99_speech")
+                ti99_32kram = system.isOptSet("ti99_32kram") and system.getOptBoolean("ti99_32kram")
+                if ti99_speech:
+                    commandLine += ["-ioport", "speechsyn"]
+                    if ti99_32kram:
+                        commandLine += ["-ioport:speechsyn:extport", "peb",
+                                        "-ioport:speechsyn:extport:peb:slot2", "32kmem"]
+                elif ti99_32kram:
+                    commandLine += ["-ioport", "peb", "-ioport:peb:slot2", "32kmem"]
 
             #Laser 310 Memory Expansion & joystick
             if system.name == "laser310":

--- a/package/system/knulli-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/system/knulli-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -313,11 +313,23 @@ class MameGenerator(Generator):
 
             #TI-99 32k RAM expansion & speech modules - enabled by default
             if system.name == "ti99":
-                commandArray += [ "-ioport", "peb" ]
-                if not system.isOptSet("ti99_32kram") or (system.isOptSet("ti99_32kram") and system.getOptBoolean("ti99_32kram")):
-                    commandArray += ["-ioport:peb:slot2", "32kmem"]
-                if not system.isOptSet("ti99_speech") or (system.isOptSet("ti99_speech") and system.getOptBoolean("ti99_speech")):
-                    commandArray += ["-ioport:peb:slot3", "speech"]
+                # The speech synthesizer attaches to the console I/O port
+                # ("-ioport speechsyn"); the Peripheral Expansion Box chains into
+                # the synth's "extport" pass-through (real-hardware topology). PEB
+                # cards such as the 32K RAM expansion live in the PEB slots.
+                # The previous layout ("-ioport peb -ioport:peb:slot3 speech") used
+                # a non-existent slot option ('speech' is not a PEB card; the synth
+                # is 'speechsyn' on the console ioport), so MAME failed to load the
+                # machine. 32K RAM stays enabled by default for the standalone core.
+                ti99_speech = not system.isOptSet("ti99_speech") or system.getOptBoolean("ti99_speech")
+                ti99_32kram = not system.isOptSet("ti99_32kram") or system.getOptBoolean("ti99_32kram")
+                if ti99_speech:
+                    commandArray += ["-ioport", "speechsyn"]
+                    if ti99_32kram:
+                        commandArray += ["-ioport:speechsyn:extport", "peb",
+                                         "-ioport:speechsyn:extport:peb:slot2", "32kmem"]
+                elif ti99_32kram:
+                    commandArray += ["-ioport", "peb", "-ioport:peb:slot2", "32kmem"]
 
             #Laser 310 Memory Expansion & Joystick
             if system.name == "laser310":


### PR DESCRIPTION
## Summary
Corrects the **TI-99/4A (`ti99`)** configuration: the right MAME command, keyboard input that actually reaches the core, and full on-board (handheld) controls. **Validated on a TrimUI Brick Hammer (Allwinner A133P, aarch64), `scarab 20260511`**, from a clean deploy of this branch.

> **Scope (honest):** these are **configuration-layer** fixes — necessary and correct, but *not sufficient alone*. On `scarab 20260511` the **stock `mame_libretro` core itself SIGSEGVs running `ti99_4a` even with the corrected command** — tracked separately in **#85** (and same family as **#81**). Playable TI-99 also needs a working MAME core; validated here against MAME 0.287.

## Changes
1. **`libretroMAMEConfig.py` + `mameGenerator.py` — correct TI-99 slot topology.** `-ioport:peb:slot3 speech` is invalid (`speech` is not a PEB-slot card; the synth is `speechsyn` on the console `ioport`, PEB chains through its `extport`). lr-mame failed to load the machine on the bad option. Fixed so speech + 32K RAM coexist.
2. **`libretroConfig.py` — `input_auto_game_focus = '2'` (general fix).** Without Game Focus, RetroArch never forwards keyboard input to the core, so **no MAME computer system** can receive keys in-game. Detect mode enables it only for keyboard cores (other systems keep hotkeys). Benefits every MAME computer system (apple2, bbc, coco, atom, electron, fm7, … and ti99); cherry-pickable on its own. Likely also helps **#82**.
3. **`board/fsoverlay/usr/share/evmapy/ti99.keys` — default on-board control map.** The libretro MAME core routes the pad only to MAME joystick inputs, never the keyboard matrix; evmapy (no-grab) emits real `KEY_*` via uinput → reaches the core once Game Focus is on. d-pad = joystick, A/B = fire, L1/R1/L2/R2/X = 1–5, Select = 0, hotkey+Start = exit.

## Testing (TrimUI Brick Hammer, A133P)
Deployed this branch to real install paths, restored the **stock** core, stripped all runtime overrides, launched a-maze-ing:
- **Stock scarab core → SIGSEGV** on the *correct* `-ioport speechsyn` command (cmdfile + fresh `.pyc` confirmed) → core defect (**#85**), not config.
- With **MAME 0.287** + this config: boots, speech runs, **digits work from the default evmapy map**, and the **d-pad moves in the maze via the joypad path with no per-machine cfg** — config side is complete.
- All four ti99 speech/32K command combinations validated via `-listslots`.

## Related
- **#85** — the TI-99 core crash this PR's config does *not* fix (the remaining blocker).
- **#81** — MAME 2010 core crash; same core-regression family.
- **#82** — MAME hotkey/input; change 2 (Game Focus) is in that area.
