### PR TITLE
sm8250: support current ABL boot requirements

### DIFF
--- a/board/qualcomm/sm8250/genimage.cfg
+++ b/board/qualcomm/sm8250/genimage.cfg
@@ -1,6 +1,6 @@
 image boot.vfat {
         vfat {
-                extraargs = "-F 32 -n KNULLI"
+                extraargs = "-F 32 -s 32 -n KNULLI"
 		@files
         }
 

--- a/board/qualcomm/sm8250/patches/grub2/001-map-suspend-key-to-enter.patch
+++ b/board/qualcomm/sm8250/patches/grub2/001-map-suspend-key-to-enter.patch
@@ -1,23 +1,15 @@
 --- a/grub-core/term/efi/console.c
 +++ b/grub-core/term/efi/console.c
-@@ -207,20 +207,25 @@ const unsigned efi_codes[] =
+@@ -204,6 +204,8 @@
+     GRUB_TERM_KEY_F10, GRUB_TERM_KEY_F11, GRUB_TERM_KEY_F12, GRUB_TERM_ESC
+   };
+ 
 +#define GRUB_EFI_SCAN_SUSPEND 0x0102
 +
  static int
  grub_efi_translate_key (grub_efi_input_key_t key)
  {
-   if (key.scan_code == 0)
-     {
-       /* Some firmware implementations use VT100-style codes against the spec.
-	 This is especially likely if driven by serial.
-        */
-       if (key.unicode_char < 0x20 && key.unicode_char != 0
-	  && key.unicode_char != '\t' && key.unicode_char != '\b'
-	  && key.unicode_char != '\n' && key.unicode_char != '\r')
-	return GRUB_TERM_CTRL | (key.unicode_char - 1 + 'a');
-       else
-	return key.unicode_char;
-     }
+@@ -222,6 +224,9 @@
    /* Some devices send enter with scan_code 0x0d (F3) and unicode_char 0x0d. */
    else if (key.scan_code == '\r' && key.unicode_char == '\r')
      return key.unicode_char;
@@ -26,3 +18,17 @@
 +    return '\r';
    else if (key.scan_code < ARRAY_SIZE (efi_codes))
      return efi_codes[key.scan_code];
+ 
+@@ -365,6 +370,12 @@
+   text_input = grub_efi_open_protocol(grub_efi_system_table->console_in_handler,
+ 				      &text_input_ex_guid,
+ 				      GRUB_EFI_OPEN_PROTOCOL_GET_PROTOCOL);
++
++  /* Discard keys queued by firmware before GRUB took over input.  This is
++     particularly important when the power button is also used as Enter. */
++  if (text_input)
++    text_input->reset (text_input, 0);
++
+   term->data = (void *)text_input;
+ 
+   return 0;

--- a/board/qualcomm/sm8250/patches/grub2/001-map-suspend-key-to-enter.patch
+++ b/board/qualcomm/sm8250/patches/grub2/001-map-suspend-key-to-enter.patch
@@ -1,0 +1,28 @@
+--- a/grub-core/term/efi/console.c
++++ b/grub-core/term/efi/console.c
+@@ -207,20 +207,25 @@ const unsigned efi_codes[] =
++#define GRUB_EFI_SCAN_SUSPEND 0x0102
++
+ static int
+ grub_efi_translate_key (grub_efi_input_key_t key)
+ {
+   if (key.scan_code == 0)
+     {
+       /* Some firmware implementations use VT100-style codes against the spec.
+	 This is especially likely if driven by serial.
+        */
+       if (key.unicode_char < 0x20 && key.unicode_char != 0
+	  && key.unicode_char != '\t' && key.unicode_char != '\b'
+	  && key.unicode_char != '\n' && key.unicode_char != '\r')
+	return GRUB_TERM_CTRL | (key.unicode_char - 1 + 'a');
+       else
+	return key.unicode_char;
+     }
+   /* Some devices send enter with scan_code 0x0d (F3) and unicode_char 0x0d. */
+   else if (key.scan_code == '\r' && key.unicode_char == '\r')
+     return key.unicode_char;
++  /* Qualcomm firmware reports the power button as EFI_SCAN_SUSPEND. */
++  else if (key.scan_code == GRUB_EFI_SCAN_SUSPEND)
++    return '\r';
+   else if (key.scan_code < ARRAY_SIZE (efi_codes))
+     return efi_codes[key.scan_code];

--- a/board/qualcomm/sm8250/rp5/genimage.cfg
+++ b/board/qualcomm/sm8250/rp5/genimage.cfg
@@ -1,6 +1,6 @@
 image boot.vfat {
         vfat {
-                extraargs = "-F 32 -n KNULLI"
+                extraargs = "-F 32 -s 32 -n KNULLI"
 		@files
         }
 

--- a/board/qualcomm/sm8250/rpflip2/genimage.cfg
+++ b/board/qualcomm/sm8250/rpflip2/genimage.cfg
@@ -1,6 +1,6 @@
 image boot.vfat {
         vfat {
-                extraargs = "-F 32 -n KNULLI"
+                extraargs = "-F 32 -s 32 -n KNULLI"
 		@files
         }
 

--- a/board/qualcomm/sm8250/rpmini/genimage.cfg
+++ b/board/qualcomm/sm8250/rpmini/genimage.cfg
@@ -1,6 +1,6 @@
 image boot.vfat {
         vfat {
-                extraargs = "-F 32 -n KNULLI"
+                extraargs = "-F 32 -s 32 -n KNULLI"
 		@files
         }
 

--- a/board/qualcomm/sm8250/rpminiv2/genimage.cfg
+++ b/board/qualcomm/sm8250/rpminiv2/genimage.cfg
@@ -1,6 +1,6 @@
 image boot.vfat {
         vfat {
-                extraargs = "-F 32 -n KNULLI"
+                extraargs = "-F 32 -s 32 -n KNULLI"
 		@files
         }
 


### PR DESCRIPTION
## Summary

- pass `-s 32` to `mkfs.fat` for every SM8250 boot filesystem
- produce the 16 KiB FAT clusters required by the current ABL
- map the Qualcomm UEFI power-button event to Enter in the SM8250 GRUB build
- clear firmware input queued before GRUB starts so the power-on press does not immediately select the first menu entry
- leave the existing FAT32 type, volume label, filesystem size, and partition layout unchanged

## Root cause

### FAT cluster size

The SM8250 ABL validates the boot partition's FAT cluster size and rejects anything other than 16,384 bytes with an `INVALID CLUSTER SIZE` screen. Without an explicit sectors-per-cluster setting, `mkfs.fat` selects the cluster size automatically and may create 32 KiB clusters for the 6 GiB boot filesystem.

With 512-byte logical sectors, `-s 32` makes each cluster 16,384 bytes.

### GRUB menu confirmation

Qualcomm UEFI reports the power button as `EFI_SCAN_SUSPEND` (`0x0102`). The ABL handles that scan code as its confirmation action, but GRUB 2.12 does not map it and returns `GRUB_TERM_NO_KEY`. As a result, the volume buttons can move through the combined SM8250 device menu while the power button cannot boot the highlighted entry.

The SM8250-specific GRUB patch translates `EFI_SCAN_SUSPEND` to carriage return, allowing the power button to act as Enter without changing other platforms.

The power-on press can remain queued in the firmware input protocol when GRUB starts. Once the power button is mapped to Enter, that stale event would immediately boot the first menu entry before the menu appeared. Resetting the extended text-input protocol during GRUB console initialization discards pre-GRUB input while preserving subsequent button presses.

## Impact

Retroid Pocket SM8250 devices can boot current images without manually reformatting the boot partition or reducing `grub.cfg` to a single menu entry. The GRUB menu remains visible, the volume buttons move between entries, and a new power-button press boots the selected entry.

## Validation

- verified all five SM8250 `genimage.cfg` files use `-F 32 -s 32 -n KNULLI`
- formatted and inspected the 6 GiB boot filesystem: 512 bytes/sector, 32 sectors/cluster, 16,384 bytes/cluster
- applied the SM8250 GRUB patch to the packaged GRUB 2.12 source with zero fuzz and cross-built the ARM64 EFI executable
- assembled and flashed a full Scarab image with Rufus on a Retroid Pocket Mini V2 using the updated ABL
- confirmed the device passes the ABL cluster-size check
- confirmed GRUB remains visible instead of automatically booting its first entry
- confirmed the volume buttons navigate the menu and the power button boots the highlighted entry
