### PR TITLE
[RG34XXSP] Permanently unbind unused USB1-3 host controllers at boot

### DIFF
--- a/board/allwinner/h700/fsoverlay/etc/init.d/S29rg34xx-sp-usb
+++ b/board/allwinner/h700/fsoverlay/etc/init.d/S29rg34xx-sp-usb
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ "$1" != "start" ]; then
+    exit 0
+fi
+
+# USB host controllers 1/2/3 (ehci1-3/ohci1-3) are not physically wired on
+# this board - usbc1/2/3 in the devicetree carry usb_host_init_state=1 and
+# no drvvbus-supply regulator (only usbc0, the real OTG/charging port, has
+# one - see rg34xx-sp.dts), so nothing can ever be attached to them.
+BOARD=$(cat /boot/boot/knulli.board)
+if [ "$BOARD" = "rg34xx-sp" ]; then
+    [ -e /sys/bus/platform/drivers/sunxi-ohci/5200000.ohci1-controller ] && echo 5200000.ohci1-controller > /sys/bus/platform/drivers/sunxi-ohci/unbind 2>/dev/null
+    [ -e /sys/bus/platform/drivers/sunxi-ehci/5200000.ehci1-controller ] && echo 5200000.ehci1-controller > /sys/bus/platform/drivers/sunxi-ehci/unbind 2>/dev/null
+    [ -e /sys/bus/platform/drivers/sunxi-ohci/5310000.ohci2-controller ] && echo 5310000.ohci2-controller > /sys/bus/platform/drivers/sunxi-ohci/unbind 2>/dev/null
+    [ -e /sys/bus/platform/drivers/sunxi-ehci/5310000.ehci2-controller ] && echo 5310000.ehci2-controller > /sys/bus/platform/drivers/sunxi-ehci/unbind 2>/dev/null
+    [ -e /sys/bus/platform/drivers/sunxi-ohci/5311000.ohci3-controller ] && echo 5311000.ohci3-controller > /sys/bus/platform/drivers/sunxi-ohci/unbind 2>/dev/null
+    [ -e /sys/bus/platform/drivers/sunxi-ehci/5311000.ehci3-controller ] && echo 5311000.ehci3-controller > /sys/bus/platform/drivers/sunxi-ehci/unbind 2>/dev/null
+fi


### PR DESCRIPTION
## Why

USB host controllers 1/2/3 (ehci1-3/ohci1-3) are not physically wired on the
rg34xx-sp board — `usbc1`/`usbc2`/`usbc3` in the devicetree carry
`usb_host_init_state=1` and no `drvvbus-supply` regulator (only `usbc0`, the
real OTG/charging port, has one — see `rg34xx-sp.dts`), so nothing can ever
be attached to them.

## What

Permanently unbind these three unused host controllers from their drivers at
boot (rg34xx-sp only), via a board-scoped `init.d` script.

## Impact

Reduces running and suspend (to memory) power draw by gating clocks/PHYs for
controllers that can never have anything attached. No functional downside, the ports are unusable regardless of driver binding.

## Testing

- Booted on rg34xx-sp, confirmed all three controllers unbind cleanly at
  boot with no dmesg errors.
- Confirmed reduced power draw.